### PR TITLE
Add support for context.Context

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 
 # cron
 
+Originally this was a fork of [github.com/tovenja/cron](github.com/tovenja/cron) which itself was a fork of
+[github.com/robfig/cron](github.com/robfig/cron) adding a more efficient storage of tasks.
+This fork makes incompatible changes to the API in order to support **context.Context**.
+
 从robfig/cron Fork出来的，不过这个cron框架经过使用后发现，大量任务会耗费很多CPU在Sort全部的任务上，每次任务执行完之后就会修改next执行时间，然后数组使用快排进行排序，时间复杂度O(nlogn)，我修改为min-heap的方式，每次添加任务的时候通过堆的属性进行up和down调整，每次添加任务时间复杂度O(logn)，经过验证线上CPU使用降低4~5倍。
 
 From robfig/cron Fork, but after using it, I found that a large number of tasks will consume a lot of CPU on all tasks of Sort. After each task executed, the next execution time will be modified, and then the array will be sorted using quick-sort, which is cost O(nlogn), I modified it to the min-heap method. When adding a task, the up and down adjustments are made through the properties of the heap. Each time the task added, the time cost is O(logn). After product env verification, the online CPU usage is reduced by 4~5 times.
@@ -11,16 +15,16 @@ Cron V3 has been released!
 
 To download the specific tagged release, run:
 ```bash
-go get github.com/tovenja/cron/v3@v3.0.0
+go get github.com/seedcx/go-cron/v3
 ```
 Import it in your program as:
 ```go
-import "github.com/tovenja/cron/v3"
+import "github.com/seedcx/go-cron/v3"
 ```
 It requires Go 1.11 or later due to usage of Go Modules.
 
 Refer to the documentation here:
-http://godoc.org/github.com/robfig/cron
+http://godoc.org/github.com/seedcx/go-cron
 
 The rest of this document describes the the advances in v3 and a list of
 breaking changes for users that wish to upgrade from an earlier version.

--- a/chain.go
+++ b/chain.go
@@ -1,6 +1,7 @@
 package cron
 
 import (
+	"context"
 	"fmt"
 	"runtime"
 	"sync"
@@ -37,7 +38,7 @@ func (c Chain) Then(j Job) Job {
 // Recover panics in wrapped jobs and log them with the provided logger.
 func Recover(logger Logger) JobWrapper {
 	return func(j Job) Job {
-		return FuncJob(func() {
+		return FuncContextJob(func(ctx context.Context) {
 			defer func() {
 				if r := recover(); r != nil {
 					const size = 64 << 10
@@ -50,7 +51,7 @@ func Recover(logger Logger) JobWrapper {
 					logger.Error(err, "panic", "stack", "...\n"+string(buf))
 				}
 			}()
-			j.Run()
+			j.Run(ctx)
 		})
 	}
 }
@@ -61,14 +62,14 @@ func Recover(logger Logger) JobWrapper {
 func DelayIfStillRunning(logger Logger) JobWrapper {
 	return func(j Job) Job {
 		var mu sync.Mutex
-		return FuncJob(func() {
+		return FuncContextJob(func(ctx context.Context) {
 			start := time.Now()
 			mu.Lock()
 			defer mu.Unlock()
 			if dur := time.Since(start); dur > time.Minute {
 				logger.Info("delay", "duration", dur)
 			}
-			j.Run()
+			j.Run(ctx)
 		})
 	}
 }
@@ -79,11 +80,11 @@ func SkipIfStillRunning(logger Logger) JobWrapper {
 	return func(j Job) Job {
 		var ch = make(chan struct{}, 1)
 		ch <- struct{}{}
-		return FuncJob(func() {
+		return FuncContextJob(func(ctx context.Context) {
 			select {
 			case v := <-ch:
 				defer func() { ch <- v }()
-				j.Run()
+				j.Run(ctx)
 			default:
 				logger.Info("skip")
 			}

--- a/cron.go
+++ b/cron.go
@@ -74,25 +74,6 @@ type Entry struct {
 // Valid returns true if this is not the zero entry.
 func (e Entry) Valid() bool { return e.ID != 0 }
 
-// byTime is a wrapper for sorting the entry array by time
-// (with zero time at the end).
-type byTime []*Entry
-
-func (s byTime) Len() int      { return len(s) }
-func (s byTime) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
-func (s byTime) Less(i, j int) bool {
-	// Two zero times should return false.
-	// Otherwise, zero is "greater" than any other time.
-	// (To sort it at the end of the list.)
-	if s[i].Next.IsZero() {
-		return false
-	}
-	if s[j].Next.IsZero() {
-		return true
-	}
-	return s[i].Next.Before(s[j].Next)
-}
-
 // New returns a new Cron job runner, modified by the given options.
 //
 // Available Settings
@@ -253,9 +234,6 @@ func (c *Cron) run() {
 
 	for {
 		// Determine the next entry to run.
-		// User min-heap no need sort anymore
-		//sort.Sort(byTime(c.entries))
-
 		var timer *time.Timer
 		if len(c.entries) == 0 || c.entries[0].Next.IsZero() {
 			// If there are no entries yet, just sleep - it still handles new entries
@@ -263,7 +241,6 @@ func (c *Cron) run() {
 			timer = time.NewTimer(100000 * time.Hour)
 		} else {
 			timer = time.NewTimer(c.entries[0].Next.Sub(now))
-			//fmt.Printf(" %v, %+v\n", c.entries[0].Next.Sub(now), c.entries[0].ID)
 		}
 
 		for {

--- a/doc.go
+++ b/doc.go
@@ -5,13 +5,13 @@ Installation
 
 To download the specific tagged release, run:
 
-	go get github.com/tovenja/cron/v3@v3.0.0
+	go get github.com/seedcx/go-cron/v3
 
 Import it in your program as:
 
-	import "github.com/tovenja/cron/v3"
+	import "github.com/seedcx/go-cron/v3"
 
-It requires Go 1.11 or later due to usage of Go Modules.
+It requires Go 1.12 or later due to usage of Go Modules.
 
 Usage
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/tovenja/cron/v3
+module github.com/seedcx/go-cron/v3
 
 go 1.12

--- a/option.go
+++ b/option.go
@@ -43,3 +43,10 @@ func WithLogger(logger Logger) Option {
 		c.logger = logger
 	}
 }
+
+// WithWaitGroup uses the provided WaitGroup for job waiting.
+func WithWaitGroup(wg WaitGroup) Option {
+	return func(c *Cron) {
+		c.waiter = wg
+	}
+}

--- a/option_test.go
+++ b/option_test.go
@@ -1,6 +1,7 @@
 package cron
 
 import (
+	"context"
 	"log"
 	"strings"
 	"testing"
@@ -31,7 +32,7 @@ func TestWithVerboseLogger(t *testing.T) {
 	}
 
 	c.AddFunc("@every 1s", func() {})
-	c.Start()
+	c.Start(context.Background())
 	time.Sleep(OneSecond)
 	c.Stop()
 	out := buf.String()


### PR DESCRIPTION
This PR adds a support for passing context.Context into running jobs. Context cancellation is also respected by the scheduler. In addition to that there is a new Option to configure a scheduler – WithWaitGroup – to make it use a user provided WaitGroup-like object (so that a caller can synchronize with a stopping scheduler).